### PR TITLE
Feature/component injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,80 @@ args.Exists("h"); // true
 To toggle the dev console, press F4 key.
 
 ![image](https://github.com/DarkRewar/BaseTool/assets/7771426/98bfceaa-62d0-45e9-8cc4-f087e2f19a5c)
+
+### Injector
+
+You can "automatically" retrieve your components by using the `Injector.Process()` method.
+
+To get your `Awake()`, `OnEnable()`, `Start()` or anything else clean, you can add attributes upon fields and properties you want to retrieve. You can use one of those five attributes following their exact method:
+- `GetComponent`
+- `GetComponents`
+- `GetComponentInChildren`
+- `GetComponentsInChildren`
+- `GetComponentInParent`
+
+```csharp
+using BaseTool.Tools;
+using BaseTool.Tools.Attributes;
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+public class MyComponent : MonoBehaviour
+{
+    [GetComponent, SerializeField]
+    private Rigidbody _rigidbody;
+
+    [GetComponent]
+    public Rigidbody Rigidbody { get; private set; }
+
+    [GetComponentInChildren]
+    public Collider ChildCollider;
+
+    [GetComponentsInChildren]
+    public Collider[] ChildrenColliders;
+
+    [GetComponentInParent]
+    public Transform ParentTransform;
+
+    void Awake() => Injector.Process(this);
+}
+```
+
+### Cooldown
+
+`Cooldown` is a class that can be used to delay a call, action or whatever you want to do. You can directly check the `Cooldown.IsReady` boolean or subscribe to the `Cooldown.OnReady` event.
+
+```csharp
+using BaseTool;
+using UnityEngine;
+
+public class MyComponent : MonoBehaviour
+{
+    [SerializeField]
+    private Cooldown _cooldown = 2;
+
+    void Start()
+    {
+        // Event method
+        _cooldown.OnReady += OnCooldownIsReady;
+    }
+
+    void Update()
+    {
+        // In both way, you need to update the cooldown
+        _cooldown.Update();
+
+        // Update boolean check method
+        if (_cooldown.IsReady)
+        {
+            _cooldown.Reset();
+            // Do something when cooldown is ready
+        }
+    }
+
+    private void OnCooldownIsReady()
+    {
+        // Do something when cooldown is ready
+    }
+}
+```

--- a/Runtime/Core/Tools/Attributes/GetComponentAttribute.cs
+++ b/Runtime/Core/Tools/Attributes/GetComponentAttribute.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace BaseTool.Tools.Attributes
+{
+    [System.AttributeUsage(System.AttributeTargets.Field | AttributeTargets.Property)]
+    public class GetComponentAttribute : Attribute { }
+
+    [System.AttributeUsage(System.AttributeTargets.Field | AttributeTargets.Property)]
+    public class GetComponentsAttribute : Attribute { }
+
+    [System.AttributeUsage(System.AttributeTargets.Field | AttributeTargets.Property)]
+    public class GetComponentInChildrenAttribute : Attribute { }
+
+    [System.AttributeUsage(System.AttributeTargets.Field | AttributeTargets.Property)]
+    public class GetComponentsInChildrenAttribute : Attribute { }
+
+    [System.AttributeUsage(System.AttributeTargets.Field | AttributeTargets.Property)]
+    public class GetComponentInParentAttribute : Attribute { }
+}

--- a/Runtime/Core/Tools/Attributes/GetComponentAttribute.cs.meta
+++ b/Runtime/Core/Tools/Attributes/GetComponentAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2c66b9abb8e84d008c9a5b65032d28f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Core/Tools/Injector.cs
+++ b/Runtime/Core/Tools/Injector.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Reflection;
+using BaseTool.Tools.Attributes;
+using UnityEngine;
+
+namespace BaseTool.Tools
+{
+    public static class Injector
+    {
+        public static void Process(MonoBehaviour go)
+        {
+            Type type = go.GetType();
+
+            System.Reflection.FieldInfo[] fields = type.GetFields(
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Public
+            );
+
+            foreach (System.Reflection.FieldInfo field in fields)
+            {
+                var comp = ExtractFromType(go, field);
+                if (comp != null)
+                    field.SetValue(go, comp);
+            }
+
+            System.Reflection.PropertyInfo[] properties = go.GetType().GetProperties(
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Public |
+                System.Reflection.BindingFlags.SetField |
+                System.Reflection.BindingFlags.GetField
+            );
+
+            foreach (System.Reflection.PropertyInfo property in properties)
+            {
+                var comp = ExtractFromType(go, property);
+                if (comp != null)
+                    property.SetValue(go, comp);
+            }
+        }
+
+        private static object ExtractFromType(MonoBehaviour go, MemberInfo memberInfo)
+        {
+            var type = memberInfo switch
+            {
+                FieldInfo fieldInfo => fieldInfo.FieldType,
+                PropertyInfo propertyInfo => propertyInfo.PropertyType,
+                _ => null
+            };
+            if (type == null) return null;
+
+            if (memberInfo.IsDefined(typeof(GetComponentAttribute), false))
+            {
+                if (go.TryGetComponent(type, out var component))
+                    return component;
+                else
+                    Debug.LogWarning($"Component {type} not found on {go.name}");
+            }
+            else if (memberInfo.IsDefined(typeof(GetComponentsAttribute), false))
+            {
+                var components = go.GetComponents(type);
+                if (components.Length != 0)
+                {
+                    var arr = Array.CreateInstance(type.GetElementType(), components.Length);
+                    Array.Copy(components, arr, components.Length);
+                    return arr;
+                }
+                else
+                    Debug.LogWarning($"Component {type} not found on {go.name}");
+            }
+            else if (memberInfo.IsDefined(typeof(GetComponentInChildrenAttribute), false))
+            {
+                var component = go.GetComponentInChildren(type);
+                if (component)
+                    return component;
+                else
+                    Debug.LogWarning($"Component {type} not found in {go.name} children");
+            }
+            else if (memberInfo.IsDefined(typeof(GetComponentsInChildrenAttribute), false))
+            {
+                Component[] components = go.GetComponentsInChildren(type.GetElementType());
+                if (components.Length != 0)
+                {
+                    var arr = Array.CreateInstance(type.GetElementType(), components.Length);
+                    Array.Copy(components, arr, components.Length);
+                    return arr;
+                }
+                else
+                    Debug.LogWarning($"Components {type} not found in {go.name} children");
+            }
+            else if (memberInfo.IsDefined(typeof(GetComponentInParentAttribute), false))
+            {
+                var component = go.GetComponentInParent(type);
+                if (component)
+                    return component;
+                else
+                    Debug.LogWarning($"Component {type} not found in {go.name} parent");
+            }
+            return null;
+        }
+
+    }
+}

--- a/Runtime/Core/Tools/Injector.cs.meta
+++ b/Runtime/Core/Tools/Injector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68e0f1ad1c6b448e1bcc3df7b467e802
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FirstPerson.meta
+++ b/Runtime/FirstPerson.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec925de9094834aa5b6256c6145f43ca
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/FirstPerson/FirstPersonController.cs
+++ b/Runtime/FirstPerson/FirstPersonController.cs
@@ -1,0 +1,28 @@
+using BaseTool.Tools;
+using BaseTool.Tools.Attributes;
+using UnityEngine;
+
+namespace BaseTool.FirstPerson
+{
+    [AddComponentMenu("BaseTool/FirstPerson")]
+    [RequireComponent(typeof(Rigidbody))]
+    public class FirstPersonController : MonoBehaviour
+    {
+        [GetComponent, SerializeField]
+        private Rigidbody _rigidbody;
+
+        [GetComponent]
+        public Rigidbody Rigidbody { get; private set; }
+
+        [GetComponentInChildren]
+        public Collider ChildCollider;
+
+        [GetComponentsInChildren, SerializeField]
+        public Collider[] ChildrenColliders;
+
+        [GetComponentInParent, SerializeField]
+        public Transform Parent;
+
+        void Awake() => Injector.Process(this);
+    }
+}

--- a/Runtime/FirstPerson/FirstPersonController.cs
+++ b/Runtime/FirstPerson/FirstPersonController.cs
@@ -1,3 +1,4 @@
+using System;
 using BaseTool.Tools;
 using BaseTool.Tools.Attributes;
 using UnityEngine;
@@ -8,20 +9,8 @@ namespace BaseTool.FirstPerson
     [RequireComponent(typeof(Rigidbody))]
     public class FirstPersonController : MonoBehaviour
     {
-        [GetComponent, SerializeField]
-        private Rigidbody _rigidbody;
-
         [GetComponent]
-        public Rigidbody Rigidbody { get; private set; }
-
-        [GetComponentInChildren]
-        public Collider ChildCollider;
-
-        [GetComponentsInChildren, SerializeField]
-        public Collider[] ChildrenColliders;
-
-        [GetComponentInParent, SerializeField]
-        public Transform Parent;
+        private Rigidbody _rigidbody;
 
         void Awake() => Injector.Process(this);
     }

--- a/Runtime/FirstPerson/FirstPersonController.cs.meta
+++ b/Runtime/FirstPerson/FirstPersonController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e66f32fe62509400a8acd2cd832fcaee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Injector Pull Request

You can "automatically" retrieve your components by using the `Injector.Process()` method.

To get your `Awake()`, `OnEnable()`, `Start()` or anything else clean, you can add attributes upon fields and properties you want to retrieve. You can use one of those five attributes following their exact method:
- `GetComponent`
- `GetComponents`
- `GetComponentInChildren`
- `GetComponentsInChildren`
- `GetComponentInParent`

```csharp
using BaseTool.Tools;
using BaseTool.Tools.Attributes;
using UnityEngine;

[RequireComponent(typeof(Rigidbody))]
public class MyComponent : MonoBehaviour
{
    [GetComponent, SerializeField]
    private Rigidbody _rigidbody;

    [GetComponent]
    public Rigidbody Rigidbody { get; private set; }

    [GetComponentInChildren]
    public Collider ChildCollider;

    [GetComponentsInChildren]
    public Collider[] ChildrenColliders;

    [GetComponentInParent]
    public Transform ParentTransform;

    void Awake() => Injector.Process(this);
}
```