### PR TITLE
Retargeting namespace to BaseTool root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 - Replace labels by float field in the `[MinMaxAttribute]` property drawer
+- Replace `BaseTool.Generic.*` namespaces to `BaseTool` [[#10](https://github.com/DarkRewar/BaseTool/pull/10)]
 
 ## 0.1.0
 

--- a/Documentation~/Extensions.md
+++ b/Documentation~/Extensions.md
@@ -22,7 +22,7 @@ Methods that extends from `Camera` :
 Changes the `Color.r`, `Color.g`, `Color.b`, `Color.a` value from a `Color` and return the new object. Why do these extensions exist? Because you can't modify a struct (like color). You always need to replace the reference.
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 using UnityEngine;
 
 public class Test
@@ -49,7 +49,7 @@ test.Color = tempColor;
 Returns a hex code from a color object:
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 
 Color red = Color.red;
 red.ToHex(); // #FF0000
@@ -61,7 +61,7 @@ Color.blue.ToHex(); // #0000FF
 Returns a hex code including alpha from a color object:
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 using UnityEngine;
 
 Color red = Color.red;
@@ -79,7 +79,7 @@ green.ToHexAlpha(); // #00FF007F
 Returns a random element from a `List<T>` using the `UnityEngine.Random` class.
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -97,7 +97,7 @@ Same as `GetRandom()` but using the `System.Random` object passed by parameter i
 Returns a random element from a `List<T>` using the `UnityEngine.Random` class and removes it from the list.
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -119,7 +119,7 @@ Same as `ExtractRandom()` but using the `System.Random` object passed by paramet
 Determines if an `int` or a `float` is one of the numbers passed by parameter.
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 
 int element = 4;
 element.IsIn(1, 2, 3, 4, 5); // true
@@ -135,7 +135,7 @@ floatElement.IsIn(5, 6, 7, 8); // true
 Determines if an `int` or a `float` is between a range of two numbers.
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 
 int element = 4;
 element.IsBetween(3, 5); // true
@@ -152,7 +152,7 @@ floatElement.IsBetween(1.3f, 4.5f); // true
 Same as `IsBetween()` but excluding both min and max.
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 
 int element = 4;
 element.IsBetween(3, 5); // true
@@ -171,7 +171,7 @@ floatElement.IsBetween(1.3f, 4.5f); // false
 Works the same as the [`UnityEngine.Random.Range()`](https://docs.unity3d.com/ScriptReference/Random.Range.html) but for `System.Random`.
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 using System;
 
 Random rand = new();
@@ -189,7 +189,7 @@ rand.Next(1.2f, 55.5f);
 hanges the `Vector3.x`, `Vector3.y` or `Vector3.z` value from a `Vector3` and return the new object. Why do these extensions exist? Because you can't modify a struct. You always need to replace the reference.
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 
 Transform player; // let's admit it's initialized
 
@@ -210,7 +210,7 @@ player.position = tempPos;
 Works like the [`Mathf.Clamp()`](https://docs.unity3d.com/ScriptReference/Mathf.Clamp.html) for `float`, but using two vectors as min and max.
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 using UnityEngine;
 
 Vector3 pos = new(1, 2, 3);
@@ -223,7 +223,7 @@ Debug.Log(pos); // (2.00, 1.00, 0.00)
 Works like the [`Vector3.Lerp()`](https://docs.unity3d.com/ScriptReference/Vector3.Lerp.html) but using a vector as the ratio.
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 using UnityEngine;
 
 Vector3 ratio = new(0, 0.5f, 1);
@@ -239,7 +239,7 @@ Debug.Log(newPos); // (-5.00, 3.00, 29.00)
 Works like the [`Vector3.InverseLerp()`](https://docs.unity3d.com/ScriptReference/Vector3.InverseLerp.html) but using a vector as the position to ratio.
 
 ```csharp
-using BaseTool.Generic.Extensions;
+using BaseTool;
 using UnityEngine;
 
 Vector3 pos = new(-5f, 3f, 29f);

--- a/Editor/2D/GridCameraEditor.cs
+++ b/Editor/2D/GridCameraEditor.cs
@@ -1,8 +1,6 @@
-﻿using UnityEngine;
+﻿using BaseTool._2D;
 using UnityEditor;
-using BaseTool._2D;
-using BaseTool.Generic.Extensions;
-using System;
+using UnityEngine;
 
 namespace BaseTool.Editor._2D
 {
@@ -18,7 +16,7 @@ namespace BaseTool.Editor._2D
         private void OnEnable()
         {
             _reference = (GridCamera)target;
-            if(_reference.TryGetComponent(out Camera camera))
+            if (_reference.TryGetComponent(out Camera camera))
             {
                 _camera = camera;
 
@@ -32,7 +30,7 @@ namespace BaseTool.Editor._2D
                 _camera.orthographic = true;
             }
 
-            if(_reference.Bounds.Count == 0)
+            if (_reference.Bounds.Count == 0)
             {
                 _reference.Bounds.Add(GetGameViewBounds());
             }
@@ -99,7 +97,7 @@ namespace BaseTool.Editor._2D
 
             DrawSelectedBounds();
 
-            if(_selectedBounds != -1)
+            if (_selectedBounds != -1)
             {
                 Handles.BeginGUI();
 
@@ -120,7 +118,7 @@ namespace BaseTool.Editor._2D
             int i = 0;
             foreach (Bounds b in _reference.Bounds)
             {
-                if(_selectedBounds != i)
+                if (_selectedBounds != i)
                 {
                     if (mousePos.x.IsBetween(b.min.x, b.max.x) && mousePos.y.IsBetween(b.min.y, b.max.y))
                     {
@@ -152,7 +150,7 @@ namespace BaseTool.Editor._2D
         {
             foreach (Bounds b in _reference.Bounds)
             {
-                if (point.x.IsBetween(b.min.x, b.max.x) && point.y.IsBetween(b.min.y, b.max.y))                   
+                if (point.x.IsBetween(b.min.x, b.max.x) && point.y.IsBetween(b.min.y, b.max.y))
                     return true;
             }
             return false;
@@ -200,7 +198,7 @@ namespace BaseTool.Editor._2D
             );
             bounds.SetMinMax(newRect.min, newRect.max);
             Debug.Log($"{bounds.center}");
-            _reference.Bounds[_selectedBounds] = bounds;            
+            _reference.Bounds[_selectedBounds] = bounds;
         }
 
         public static Rect ResizeRect(Rect rect, Handles.CapFunction capFunc, Color capCol, Color fillCol, float capSize, float snap)

--- a/Editor/Core/Tools/Drawers/MinMaxDrawer.cs
+++ b/Editor/Core/Tools/Drawers/MinMaxDrawer.cs
@@ -1,8 +1,7 @@
-﻿using BaseTool.Tools.Attributes;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
 
-namespace BaseTool.Tools.Drawers
+namespace BaseTool.Editor.Tools.Drawers
 {
     [CustomPropertyDrawer(typeof(MinMaxAttribute))]
     public class MinMaxDrawer : PropertyDrawer

--- a/Editor/Core/Wizard/GlobalDefineInitializer.cs
+++ b/Editor/Core/Wizard/GlobalDefineInitializer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Reflection;
 using System.Text;
-using Codice.Utils;
 using UnityEditor;
 using UnityEngine;
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ To open the setup wizard, go to the topbar and open `Window > BaseTool > Setup`.
 You can add/remove you own command to the `Console` by using :
 
 ```csharp
-BaseTool.Core.Consoles.Console.AddCommand("<command>", "<description>", MethodCallback);
+BaseTool.Console.AddCommand("<command>", "<description>", MethodCallback);
 
-BaseTool.Core.Consoles.Console.RemoveCommand("<command>");
+BaseTool.Console.RemoveCommand("<command>");
 ```
 
 Here is an implementation inside a `MonoBehaviour`:
 
 ```csharp
-using BaseTool.Core.Consoles;
+using BaseTool;
 
 public class AddCustomCommand : MonoBehaviour
 {
@@ -109,8 +109,7 @@ To get your `Awake()`, `OnEnable()`, `Start()` or anything else clean, you can a
 - `GetComponentInParent`
 
 ```csharp
-using BaseTool.Tools;
-using BaseTool.Tools.Attributes;
+using BaseTool;
 using UnityEngine;
 
 [RequireComponent(typeof(Rigidbody))]
@@ -218,7 +217,7 @@ Methods available from the `MathUtils` static class:
 Because `%` is broken on C# when you want to get a negative modulo (e.g. you want the index -1 of an array), this method is a replacement of the symbol. 
 
 ```csharp
-using BaseTool.Generic.Utils; 
+using BaseTool; 
 
 MathUtils.Modulo(1, 5); // = 1
 MathUtils.Modulo(6, 5); // = 1
@@ -231,7 +230,7 @@ MathUtils.Modulo(-3, 5); // = 2
 A generic tree system following a parent/child link. Here is a following example based on a GameObject hierarchy (but would work for a file, UI or node hierarchy too).
 
 ```csharp
-using BaseTool.Generic.Utils;
+using BaseTool;
 using UnityEngine;
 
 // Create a tree from a GameObject
@@ -287,8 +286,7 @@ This attribute allows you to put a slider range for a value in the inspector. It
 ![min_max_attribute](./Documentation~/Editor/min_max_attribute.png)
 
 ```csharp
-using BaseTool.Generic.Extensions;
-using BaseTool.Tools.Attributes;
+using BaseTool;
 using UnityEngine;
 
 public class MyClass : MonoBehaviour

--- a/Runtime/2D/GridCamera.cs
+++ b/Runtime/2D/GridCamera.cs
@@ -1,18 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using UnityEngine;
-using BaseTool.Generic.Extensions;
-
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 
 namespace BaseTool._2D
 {
-    //voir ça : https://forum.unity.com/threads/button-in-scene-view.259913/
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <seealso href="https://forum.unity.com/threads/button-in-scene-view.259913/"/>
     [RequireComponent(typeof(Camera)), AddComponentMenu("BaseTool/2D/GridCamera")]
     public class GridCamera : MonoBehaviour
     {
@@ -30,12 +24,12 @@ namespace BaseTool._2D
 
         public void Start()
         {
-            if(TryGetComponent(out Camera cam))
+            if (TryGetComponent(out Camera cam))
             {
                 _camera = cam;
             }
 
-            if(_currentBoundIndex == -1)
+            if (_currentBoundIndex == -1)
             {
                 BindBounds();
             }

--- a/Runtime/Core/Consoles/Console.cs
+++ b/Runtime/Core/Consoles/Console.cs
@@ -3,38 +3,38 @@ using System.Globalization;
 using System.Text;
 using UnityEngine;
 
-namespace BaseTool.Core.Consoles
+namespace BaseTool
 {
     public class Console
     {
         private const int HistoryCount = 50;
-        
+
         private static string LastMsg = "";
         private static double TimeLastMsg;
         private static int ConsoleShowLastLine = 0;
-        
+
         private static List<string> PendingCommands = new();
         public static int PendingCommandsWaitForFrames = 0;
         public static bool PendingCommandsWaitForLoad = false;
-        
-        private static Dictionary<string, ConsoleCommand> _commands = new();    
+
+        private static Dictionary<string, ConsoleCommand> _commands = new();
         private static string[] History = new string[HistoryCount];
         private static int HistoryNextIndex = 0;
         private static int HistoryIndex = 0;
-        
+
         private static ConsoleManager _consoleManager;
 
         public Console()
         {
             var go = new GameObject("Console (manager)");
             Object.DontDestroyOnLoad(go);
-            
+
             _consoleManager = go.AddComponent<ConsoleManager>();
-            
+
             AddCommand("help", "How to use the command", HelpCommand);
             AddCommand("list", "Display the list of commands", ListCommand);
-        }   
-        
+        }
+
         private static void OutputString(string message)
         {
             if (_consoleManager == null)
@@ -51,7 +51,7 @@ namespace BaseTool.Core.Consoles
             }
             OutputString(msg);
         }
-        
+
         private static string ParseQuoted(string input, ref int pos)
         {
             ++pos;
@@ -78,8 +78,8 @@ namespace BaseTool.Core.Consoles
                 ++pos;
             }
             return input.Substring(startIndex);
-        }    
-        
+        }
+
         private static List<string> Tokenize(string input)
         {
             int pos = 0;
@@ -118,20 +118,20 @@ namespace BaseTool.Core.Consoles
             ++HistoryIndex;
             return History[HistoryIndex % 50];
         }
-        
+
         public static ConsoleArguments ParseArguments(string[] argument) => new ConsoleArguments(argument);
-        
+
         private static void SkipWhite(string input, ref int pos)
         {
             while (pos < input.Length && " \t".IndexOf(input[pos]) > -1)
                 ++pos;
         }
-        
+
         #region UPDATES
-        
+
         public static void ConsoleUpdate()
         {
-            double num = (double) Time.time - TimeLastMsg;
+            double num = (double)Time.time - TimeLastMsg;
             //IconikFramework.Console.Console.s_ConsoleUI.ConsoleUpdate();
             while (PendingCommands.Count > 0)
             {
@@ -147,11 +147,11 @@ namespace BaseTool.Core.Consoles
                 ExecuteCommand(pendingCommand);
             }
         }
-        
+
         #endregion
-        
+
         #region COMMAND EXECUTION
-        
+
         public static void ExecuteCommand(string command)
         {
             List<string> stringList = Tokenize(command);
@@ -177,14 +177,14 @@ namespace BaseTool.Core.Consoles
             HistoryIndex = HistoryNextIndex;
             EnqueueCommandNoHistory(command);
         }
-        
+
         public static string TabComplete(string prefix)
         {
             List<string> stringList = new List<string>();
             foreach (KeyValuePair<string, ConsoleCommand> command in _commands)
             {
                 string key = command.Key;
-                if (key.StartsWith(prefix, true, (CultureInfo) null))
+                if (key.StartsWith(prefix, true, (CultureInfo)null))
                     stringList.Add(key);
             }
             if (stringList.Count == 0)
@@ -208,16 +208,16 @@ namespace BaseTool.Core.Consoles
             int num = Mathf.Min(a.Length, b.Length);
             for (int length = 1; length <= num; ++length)
             {
-                if (!a.StartsWith(b.Substring(0, length), true, (CultureInfo) null))
+                if (!a.StartsWith(b.Substring(0, length), true, (CultureInfo)null))
                     return length - 1;
             }
             return num;
         }
-        
+
         #endregion
-        
+
         #region COMMANDS
-        
+
         public static void AddCommand(
             string name,
             string description,
@@ -247,22 +247,22 @@ namespace BaseTool.Core.Consoles
             }
             OutputString(sb.ToString());
         }
-        
+
         #endregion
-        
+
         #region AUTOLOAD
 
         private static Console _instance;
 
         public static Console Instance => _instance ?? Init();
-        
+
         [RuntimeInitializeOnLoadMethod]
         public static Console Init()
         {
             _instance = new Console();
             return _instance;
         }
-        
+
         #endregion
     }
 }

--- a/Runtime/Core/Consoles/ConsoleArguments.cs
+++ b/Runtime/Core/Consoles/ConsoleArguments.cs
@@ -2,12 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace BaseTool.Core.Consoles
+namespace BaseTool
 {
     public class ConsoleArguments
     {
         public readonly string[] RawArgs;
-        
+
         private List<string> _mainParams;
         private Dictionary<string, string> _argumentsParams;
 
@@ -38,7 +38,7 @@ namespace BaseTool.Core.Consoles
                 if (flag)
                 {
                     key = str.Substring(1);
-                    _argumentsParams.Add(key, (string) null);
+                    _argumentsParams.Add(key, (string)null);
                 }
                 else if (!flag && key != "")
                 {
@@ -67,7 +67,7 @@ namespace BaseTool.Core.Consoles
             {
                 sb.Append($"\n[{mainParam}]");
             }
-            
+
             foreach (var argParam in _argumentsParams)
             {
                 sb.Append($"\n[{argParam.Key} = {argParam.Value}]");

--- a/Runtime/Core/Consoles/ConsoleCommand.cs
+++ b/Runtime/Core/Consoles/ConsoleCommand.cs
@@ -1,4 +1,4 @@
-namespace BaseTool.Core.Consoles
+namespace BaseTool
 {
     public delegate void MethodDelegate(ConsoleArguments args);
 

--- a/Runtime/Core/Consoles/ConsoleManager.cs
+++ b/Runtime/Core/Consoles/ConsoleManager.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace BaseTool.Core.Consoles
+namespace BaseTool
 {
     [RequireComponent(typeof(UIDocument))]
     public class ConsoleManager : MonoBehaviour
@@ -24,7 +24,7 @@ namespace BaseTool.Core.Consoles
         private void OnEnable()
         {
             _scrollView = _uiDocument.rootVisualElement.Q<ScrollView>("ConsoleScroll");
-            
+
             _textField = _uiDocument.rootVisualElement.Q<TextField>("ConsoleField");
             _textField.RegisterCallback<KeyDownEvent>(OnConsoleFieldKeyDown, TrickleDown.TrickleDown);
             _textField.RegisterCallback<NavigationSubmitEvent>(e =>
@@ -34,10 +34,16 @@ namespace BaseTool.Core.Consoles
             }, TrickleDown.TrickleDown);
         }
 
+        private void OnDestroy()
+        {
+            Console.RemoveCommand("help");
+            Console.RemoveCommand("list");
+        }
+
         private void Update()
         {
             Console.ConsoleUpdate();
-            
+
             if (!Input.GetKeyDown(KeyCode.F4)) return;
             Toggle();
         }
@@ -45,12 +51,12 @@ namespace BaseTool.Core.Consoles
         private void Toggle()
         {
             _displayed = !_displayed;
-            _uiDocument.rootVisualElement.style.display = 
-                _displayed 
-                    ? DisplayStyle.Flex 
+            _uiDocument.rootVisualElement.style.display =
+                _displayed
+                    ? DisplayStyle.Flex
                     : DisplayStyle.None;
-            
-            if(_displayed) _textField.ElementAt(0).Focus();
+
+            if (_displayed) _textField.ElementAt(0).Focus();
         }
 
         public void WriteLine(string txt)
@@ -66,7 +72,7 @@ namespace BaseTool.Core.Consoles
                 var completion = Console.TabComplete(_textField.text).TrimEnd();
                 _textField.SetValueWithoutNotify(completion);
             }
-            
+
             if (evt.keyCode != KeyCode.Return) return;
 
             Console.EnqueueCommand(_textField.text);

--- a/Runtime/Core/Consoles/Resources/ConsolePanelSettings.asset
+++ b/Runtime/Core/Consoles/Resources/ConsolePanelSettings.asset
@@ -12,10 +12,14 @@ MonoBehaviour:
   m_Script: {fileID: 19101, guid: 0000000000000000e000000000000000, type: 0}
   m_Name: ConsolePanelSettings
   m_EditorClassIdentifier: 
-  themeUss: {fileID: -4733365628477956816, guid: 92b4259311bd744afbdf04903c2b546a, type: 3}
+  themeUss: {fileID: -4733365628477956816, guid: 92b4259311bd744afbdf04903c2b546a,
+    type: 3}
   m_TargetTexture: {fileID: 0}
+  m_RenderMode: 0
+  m_WorldSpaceLayer: 0
   m_ScaleMode: 0
   m_ReferenceSpritePixelsPerUnit: 100
+  m_PixelsPerUnit: 100
   m_Scale: 2
   m_ReferenceDpi: 96
   m_FallbackDpi: 96
@@ -24,9 +28,11 @@ MonoBehaviour:
   m_Match: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+  m_BindingLogLevel: 0
   m_ClearDepthStencil: 1
   m_ClearColor: 0
   m_ColorClearValue: {r: 0, g: 0, b: 0, a: 0}
+  m_VertexBudget: 0
   m_DynamicAtlasSettings:
     m_MinAtlasSize: 64
     m_MaxAtlasSize: 4096

--- a/Runtime/Core/Extensions/CameraExtensions.cs
+++ b/Runtime/Core/Extensions/CameraExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace BaseTool.Generic.Extensions
+namespace BaseTool
 {
     public static class CameraExtensions
     {

--- a/Runtime/Core/Extensions/ColorExtensions.cs
+++ b/Runtime/Core/Extensions/ColorExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace BaseTool.Generic.Extensions
+namespace BaseTool
 {
     public static class ColorExtensions
     {

--- a/Runtime/Core/Extensions/ListExtensions.cs
+++ b/Runtime/Core/Extensions/ListExtensions.cs
@@ -1,10 +1,9 @@
-﻿using UnityEngine;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
-namespace BaseTool.Generic.Extentions
+namespace BaseTool
 {
-    public static class ListExtensions 
+    public static class ListExtensions
     {
         public static T GetRandom<T>(this List<T> list)
         {

--- a/Runtime/Core/Extensions/NumberExtensions.cs
+++ b/Runtime/Core/Extensions/NumberExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-namespace BaseTool.Generic.Extensions
+namespace BaseTool
 {
     public static class NumberExtensions
     {

--- a/Runtime/Core/Extensions/RandomExtensions.cs
+++ b/Runtime/Core/Extensions/RandomExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace BaseTool.Generic.Extensions
+namespace BaseTool
 {
     public static class RandomExtensions
     {

--- a/Runtime/Core/Extensions/StringExtensions.cs
+++ b/Runtime/Core/Extensions/StringExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text;
 
-namespace BaseTool.Generic.Extensions
+namespace BaseTool
 {
     /// <summary>
     /// StringUtils permet d'ajouter des extensions de méthodes

--- a/Runtime/Core/Extensions/Vector3Extensions.cs
+++ b/Runtime/Core/Extensions/Vector3Extensions.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace BaseTool.Generic.Extensions
+namespace BaseTool
 {
     public static class Vector3Extensions
     {

--- a/Runtime/Core/MonoSingleton.cs
+++ b/Runtime/Core/MonoSingleton.cs
@@ -16,7 +16,7 @@ namespace BaseTool
         /// The current instance of the singleton.
         /// </summary>
         public static T Instance { get; protected set; }
-        
+
         [Header("Singleton Settings"), SerializeField]
         protected bool _dontDestroyOnLoad = false;
 
@@ -27,12 +27,12 @@ namespace BaseTool
                 DestroyImmediate(gameObject);
                 return;
             }
-            else if(Instance == null)
+            else if (Instance == null)
             {
                 Instance = this as T;
             }
 
-            if(_dontDestroyOnLoad)
+            if (_dontDestroyOnLoad)
                 DontDestroyOnLoad(this);
         }
 
@@ -44,19 +44,19 @@ namespace BaseTool
         /// <returns></returns>
         public static T GetOrCreateInstance(bool dontDestroy = false)
         {
-            if(!Instance)
+            if (!Instance)
             {
-                Instance = FindObjectOfType<T>();
+                Instance = FindAnyObjectByType<T>();
             }
 
-            if(!Instance)
+            if (!Instance)
             {
                 GameObject instanceObj = new GameObject($"{typeof(T).Name} (singleton)");
                 Instance = instanceObj.AddComponent<T>();
                 if (dontDestroy)
                     DontDestroyOnLoad(instanceObj);
             }
-        
+
             return Instance;
         }
     }

--- a/Runtime/Core/Tools/Attributes/GetComponentAttribute.cs
+++ b/Runtime/Core/Tools/Attributes/GetComponentAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace BaseTool.Tools.Attributes
+namespace BaseTool
 {
     [System.AttributeUsage(System.AttributeTargets.Field | AttributeTargets.Property)]
     public class GetComponentAttribute : Attribute { }

--- a/Runtime/Core/Tools/Attributes/MinMaxAttribute.cs
+++ b/Runtime/Core/Tools/Attributes/MinMaxAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace BaseTool.Tools.Attributes
+namespace BaseTool
 {
     public class MinMaxAttribute : PropertyAttribute
     {

--- a/Runtime/Core/Tools/Injector.cs
+++ b/Runtime/Core/Tools/Injector.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Reflection;
-using BaseTool.Tools.Attributes;
 using UnityEngine;
 
-namespace BaseTool.Tools
+namespace BaseTool
 {
     public static class Injector
     {

--- a/Runtime/Core/Utils/MathUtils.cs
+++ b/Runtime/Core/Utils/MathUtils.cs
@@ -1,4 +1,4 @@
-﻿namespace BaseTool.Generic.Utils
+﻿namespace BaseTool
 {
     public static class MathUtils
     {

--- a/Runtime/Core/Utils/Tree.cs
+++ b/Runtime/Core/Utils/Tree.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 
-namespace BaseTool.Generic.Utils
+namespace BaseTool
 {
     public class Tree<T> : IEnumerable<Tree<T>>
     {

--- a/Runtime/Movement/FirstPersonController.cs
+++ b/Runtime/Movement/FirstPersonController.cs
@@ -1,11 +1,8 @@
-using System;
-using BaseTool.Tools;
-using BaseTool.Tools.Attributes;
 using UnityEngine;
 
 namespace BaseTool.Movement
 {
-    [AddComponentMenu("BaseTool/First Person Controller")]
+    [AddComponentMenu("BaseTool/Movement/First Person Controller")]
     [RequireComponent(typeof(Rigidbody))]
     public class FirstPersonController : MonoBehaviour, IMovable
     {

--- a/Runtime/Movement/JumpController.cs
+++ b/Runtime/Movement/JumpController.cs
@@ -1,10 +1,8 @@
-using BaseTool.Tools;
-using BaseTool.Tools.Attributes;
 using UnityEngine;
 
 namespace BaseTool.Movement
 {
-    [AddComponentMenu("BaseTool/Jump Controller")]
+    [AddComponentMenu("BaseTool/Movement/Jump Controller")]
     [RequireComponent(typeof(Rigidbody))]
     public class JumpController : MonoBehaviour, IJumpable
     {

--- a/Runtime/Movement/OldMovementInput.cs
+++ b/Runtime/Movement/OldMovementInput.cs
@@ -1,9 +1,8 @@
-using BaseTool.Tools;
-using BaseTool.Tools.Attributes;
 using UnityEngine;
 
 namespace BaseTool.Movement
 {
+    [AddComponentMenu("BaseTool/Movement/Old Movement Input")]
     public class OldMovementInput : MonoBehaviour
     {
         [SerializeField]

--- a/Runtime/Movement/SideViewController.cs
+++ b/Runtime/Movement/SideViewController.cs
@@ -1,10 +1,8 @@
-using BaseTool.Tools;
-using BaseTool.Tools.Attributes;
 using UnityEngine;
 
 namespace BaseTool.Movement
 {
-    [AddComponentMenu("BaseTool/Side View Controller")]
+    [AddComponentMenu("BaseTool/Movement/Side View Controller")]
     [RequireComponent(typeof(Rigidbody))]
     public class SideViewController : MonoBehaviour, IMovable
     {

--- a/Runtime/Shooter/OldShootInput.cs
+++ b/Runtime/Shooter/OldShootInput.cs
@@ -1,5 +1,3 @@
-using BaseTool.Tools;
-using BaseTool.Tools.Attributes;
 using UnityEngine;
 
 namespace BaseTool.Shooter

--- a/Runtime/UI/Navigation.cs
+++ b/Runtime/UI/Navigation.cs
@@ -1,6 +1,5 @@
-using System.Collections.Generic;
-using BaseTool.Generic.Utils;
 using BaseTool.UI.Views;
+using System.Collections.Generic;
 
 namespace BaseTool.UI
 {
@@ -17,7 +16,7 @@ namespace BaseTool.UI
         public static void RegisterView(AView page)
         {
             _registeredViews.Add(page);
-            if(!page.Parent)
+            if (!page.Parent)
             {
                 _treeViews.AddChild(page.Tree);
             }
@@ -26,9 +25,9 @@ namespace BaseTool.UI
         private static bool TryGetRegisteredView<T>(out T view) where T : AView
         {
             view = null;
-            foreach(AView aView in _registeredViews)
-            { 
-                if(aView is T castedPage)
+            foreach (AView aView in _registeredViews)
+            {
+                if (aView is T castedPage)
                 {
                     view = castedPage;
                     return true;
@@ -40,9 +39,9 @@ namespace BaseTool.UI
         private static bool TryGetRegisteredViews<T>(out T[] views) where T : AView
         {
             List<T> foundViews = new List<T>();
-            foreach(AView aView in _registeredViews)
-            { 
-                if(aView is T castedPage)
+            foreach (AView aView in _registeredViews)
+            {
+                if (aView is T castedPage)
                 {
                     foundViews.Add(castedPage);
                 }
@@ -53,7 +52,7 @@ namespace BaseTool.UI
 
         public static void Open<T>(NavigationArgs args = null) where T : AView
         {
-            if(TryGetRegisteredView(out T view))
+            if (TryGetRegisteredView(out T view))
             {
                 Open(view, args);
             }
@@ -71,11 +70,11 @@ namespace BaseTool.UI
 
         public static void Open<T1, T2>(NavigationArgs args = null) where T1 : AView where T2 : AView
         {
-            if(TryGetRegisteredViews(out T1[] views))
+            if (TryGetRegisteredViews(out T1[] views))
             {
-                foreach(T1 aView in views)
+                foreach (T1 aView in views)
                 {
-                    if(aView.FindInChildren(out T2 childView))
+                    if (aView.FindInChildren(out T2 childView))
                     {
                         Open(childView, args);
                     }
@@ -93,11 +92,11 @@ namespace BaseTool.UI
 
         public static void Back()
         {
-            if(_history.Count != 0)
+            if (_history.Count != 0)
             {
                 NavigationEntry navigationEntry = _history.Pop();
                 navigationEntry?.View.Display(false);
-                if(CurrentView != null)
+                if (CurrentView != null)
                     navigationEntry?.View.OnNavigateTo(CurrentView.View, CurrentView.Args);
 
                 CurrentView?.View.Display(true);

--- a/Runtime/UI/Views/AView.cs
+++ b/Runtime/UI/Views/AView.cs
@@ -1,7 +1,4 @@
-﻿using BaseTool.Generic.Utils;
-using System;
-using System.Collections;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace BaseTool.UI.Views
 {
@@ -49,7 +46,7 @@ namespace BaseTool.UI.Views
         protected void SetupTree()
         {
             Tree.Current = this;
-            if(transform.parent)
+            if (transform.parent)
             {
                 AView parent = transform.parent.GetComponentInParent<AView>();
                 if (parent != null)
@@ -64,13 +61,13 @@ namespace BaseTool.UI.Views
         {
             foreach (Tree<AView> aView in Tree)
             {
-                if(aView.Current is T2 child)
+                if (aView.Current is T2 child)
                 {
                     childView = child;
                     return true;
                 }
-                
-                if(aView.Current.FindInChildren(out childView))
+
+                if (aView.Current.FindInChildren(out childView))
                 {
                     return true;
                 }


### PR DESCRIPTION
Replacing every sub namespace of the core module to `BaseTool`

See #9 for more information