### PR TITLE
Add ReadOnly Attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog 
 
+## 0.3.0
+
+### Improvements
+
+- Add `ReadOnly` attribute [[#19](https://github.com/DarkRewar/BaseTool/issues/19)]
+
+### Changes
+
 ## 0.2.0
 
 ### Improvements

--- a/Editor/Core/Tools/Drawers/ReadOnlyDrawer.cs
+++ b/Editor/Core/Tools/Drawers/ReadOnlyDrawer.cs
@@ -1,0 +1,16 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace BaseTool.Tools.Drawers
+{
+    [CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
+    internal class ReadOnlyDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            GUI.enabled = false;
+            EditorGUI.PropertyField(position, property, label);
+            GUI.enabled = true;
+        }
+    }
+}

--- a/Editor/Core/Tools/Drawers/ReadOnlyDrawer.cs.meta
+++ b/Editor/Core/Tools/Drawers/ReadOnlyDrawer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6f2d4fd34a3efa8428a46b286342b05f

--- a/README.md
+++ b/README.md
@@ -577,3 +577,18 @@ public class MyClass : MonoBehaviour
     public GameObject ProjectilePrefab;
 }
 ```
+
+### `ReadOnlyAttribute`
+
+This attribute can mark the field or property as disabled in inspector (unchangeable).
+
+```csharp
+using BaseTool;
+using UnityEngine;
+
+public class MyClass : MonoBehaviour
+{
+    [ReadOnly]
+    public int Lifepoints = 10;
+}
+```

--- a/Runtime/Core/Tools/Attributes/ReadOnlyAttribute.cs
+++ b/Runtime/Core/Tools/Attributes/ReadOnlyAttribute.cs
@@ -1,0 +1,8 @@
+﻿using UnityEngine;
+
+namespace BaseTool
+{
+    public class ReadOnlyAttribute : PropertyAttribute
+    {
+    }
+}

--- a/Runtime/Core/Tools/Attributes/ReadOnlyAttribute.cs.meta
+++ b/Runtime/Core/Tools/Attributes/ReadOnlyAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eeb1e0635ca8d2d4796375827017bf81


### PR DESCRIPTION
### `ReadOnlyAttribute`

This attribute can mark the field or property as disabled in inspector (unchangeable).

```csharp
using BaseTool;
using UnityEngine;

public class MyClass : MonoBehaviour
{
    [ReadOnly]
    public int Lifepoints = 10;
}
```