### PR TITLE
Add ValueListener #30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `ReadOnly` attribute [[#19](https://github.com/DarkRewar/BaseTool/issues/19)]
 - Add `Todo List` editor feature [[#26](https://github.com/DarkRewar/BaseTool/issues/26)]
+- Add `ValueListener` feature [[#30](https://github.com/DarkRewar/BaseTool/issues/30)]
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ How to install:
     - [Injector](#injector)
     - [Cooldown](#cooldown)
     - [MonoSingleton](#monosingleton)
+    - [ValueListener](#valuelistener)
     - [GameEvent](#game-events)
     - [Class Extensions](#class-extensions)
     - [Math Utils](#math-utils)
@@ -208,6 +209,45 @@ public class GameManager : MonoBehaviour
         MyUniquePlayer.Instance.Life -= damages;
     }
 }
+```
+
+### ValueListener
+
+If you want to use an Observer Pattern for a value, and you don't want
+to implement the entire change event handler, the `ValueListener<T>` lets
+you do that for you.
+
+You need to declare a `ValueListener<T>` of your type as a field or a property.
+I recommend to declare it as readonly to avoid loosing the `OnChanged` event references.
+
+Value is implicitly casted to or from the value type you want. That means you can initialize
+your object using the value directly (see following example).
+
+```csharp
+using BaseTool;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class MyComponent : MonoBehaviour
+{
+    public readonly ValueListener<int> Lifepoints = 100;
+    public readonly ValueListener<string> Nickname = new();
+
+    public Text NameLabel;
+    public Text LifeLabel;
+
+    public void Start()
+    {
+        Lifepoints.OnChanged += (oldLife, newLife) => 
+            LifeLabel.text = $"{oldLife} -> {newLife}/100";
+        Nickname.OnChanged += (_, newName) => 
+            NameLabel.text = newName;
+
+        Nickname.Value = "MyName";
+        string name = Nickname;
+        Debug.Log(name);
+    }
+} 
 ```
 
 ### Game Events

--- a/Runtime/Core/Utils/ValueListener.cs
+++ b/Runtime/Core/Utils/ValueListener.cs
@@ -1,0 +1,34 @@
+﻿namespace BaseTool
+{
+    /// <summary>
+    /// Observer pattern to handle value change events.
+    /// It is recommended to declare your value as a readonly 
+    /// property/field and only modify the <see cref="Value"/>
+    /// to trigger the <see cref="OnChanged"/> event.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public sealed class ValueListener<T>
+    {
+        private T _value;
+        public T Value
+        {
+            get => _value;
+            set
+            {
+                var oldValue = _value;
+                _value = value;
+                OnChanged?.Invoke(oldValue, _value);
+            }
+        }
+
+        public event ValueChangedEventHandler OnChanged;
+        public delegate void ValueChangedEventHandler(T oldValue, T newValue);
+
+        public ValueListener() => _value = default;
+
+        public ValueListener(T value) => _value = value;
+
+        public static implicit operator ValueListener<T>(T value) => new(value);
+        public static implicit operator T(ValueListener<T> listener) => listener.Value;
+    }
+}

--- a/Runtime/Core/Utils/ValueListener.cs.meta
+++ b/Runtime/Core/Utils/ValueListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6ba0c94bd37d8c478c44ece32ca1950
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### ValueListener

If you want to use an Observer Pattern for a value, and you don't want
to implement the entire change event handler, the `ValueListener<T>` lets
you do that for you.

You need to declare a `ValueListener<T>` of your type as a field or a property.
I recommend to declare it as readonly to avoid loosing the `OnChanged` event references.

Value is implicitly casted to or from the value type you want. That means you can initialize
your object using the value directly (see following example).

```csharp
using BaseTool;
using UnityEngine;
using UnityEngine.UI;

public class MyComponent : MonoBehaviour
{
    public readonly ValueListener<int> Lifepoints = 100;
    public readonly ValueListener<string> Nickname = new();

    public Text NameLabel;
    public Text LifeLabel;

    public void Start()
    {
        Lifepoints.OnChanged += (oldLife, newLife) => 
            LifeLabel.text = $"{oldLife} -> {newLife}/100";
        Nickname.OnChanged += (_, newName) => 
            NameLabel.text = newName;

        Nickname.Value = "MyName";
        string name = Nickname;
        Debug.Log(name);
    }
} 
```