### PR TITLE
Add #36 - Data Folders from Window menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `Todo List` editor feature [[#26](https://github.com/DarkRewar/BaseTool/issues/26)]
 - Add `ValueListener` feature [[#30](https://github.com/DarkRewar/BaseTool/issues/30)]
 - Add support links to the documentation and issues pages [[#32](https://github.com/DarkRewar/BaseTool/issues/32)]
+- Add buttons to open data and persistent data paths [[#36](https://github.com/DarkRewar/BaseTool/issues/36)]
 
 ### Changes
 

--- a/Editor/Core/Tools/OpenFolders.cs
+++ b/Editor/Core/Tools/OpenFolders.cs
@@ -1,0 +1,20 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace BaseTool.Editor
+{
+    public static class OpenFolders
+    {
+        [MenuItem("Window/BaseTool/Open Persistent Data Folder", priority = 211)]
+        public static void OpenPersistentDataFolder()
+        {
+            EditorUtility.OpenWithDefaultApp(Application.persistentDataPath);
+        }
+
+        [MenuItem("Window/BaseTool/Open Data Folder", priority = 210)]
+        public static void OpenDataFolder()
+        {
+            EditorUtility.OpenWithDefaultApp(Application.dataPath);
+        }
+    }
+}

--- a/Editor/Core/Tools/OpenFolders.cs.meta
+++ b/Editor/Core/Tools/OpenFolders.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90f27c727c3944c9580253d034a24ebe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -566,6 +566,16 @@ This object refers to a category that could be assigned to a weapon. It is used 
 
 ## Editor
 
+### Misc Buttons
+
+The package contains useful buttons/links directly accesible from the `Window` menu.
+Here are their functions:
+
+- `Window > BaseTool > Documentation` will open the documentation ;
+- `Window > BaseTool > Report a bug...` will redirect you to the [issue](https://github.com/DarkRewar/BaseTool/issues) page ;
+- `Window > BaseTool > Open Data Folder` will open the `Application.dataPath` in the Explorer/Finder ;
+- `Window > BaseTool > Open Persistent Data Folder` will open the `Application.persistentDataPath` in the Explorer/Finder.
+
 ### Todo List
 
 If you go to `Window > BaseTool > Todo List`, you can get an editor window that opens.


### PR DESCRIPTION
### Misc Buttons

The package contains useful buttons/links directly accesible from the `Window` menu.
Here are their functions:

- `Window > BaseTool > Documentation` will open the documentation ;
- `Window > BaseTool > Report a bug...` will redirect you to the [issue](https://github.com/DarkRewar/BaseTool/issues) page ;
- `Window > BaseTool > Open Data Folder` will open the `Application.dataPath` in the Explorer/Finder ;
- `Window > BaseTool > Open Persistent Data Folder` will open the `Application.persistentDataPath` in the Explorer/Finder.