### PR TITLE
Created a `CooldownManager` to update all `Cooldown`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a custom drawer for `ValueListener` [[#41](https://github.com/DarkRewar/BaseTool/issues/41)]
 - Add array and range extensions [[#39](https://github.com/DarkRewar/BaseTool/issues/39)]
 - Add string extensions documentation [[#49](https://github.com/DarkRewar/BaseTool/issues/49)]
+- Add `CooldownManager` to update every `Cooldown` automatically [[#63](https://github.com/DarkRewar/BaseTool/pull/63)]
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ public class MyComponent : MonoBehaviour
 
 `Cooldown` is a class that can be used to delay a call, action or whatever you want to do. You can directly check the `Cooldown.IsReady` boolean or subscribe to the `Cooldown.OnReady` event.
 
+Every `Cooldown` is updated by an internal `CooldownManager`, you don't have to call the `Cooldown.Update()` method yourself.
+If you want to manage the cooldown, you can set the `Cooldown.SubscribeToManager` to false.
+
 ```csharp
 using BaseTool;
 using UnityEngine;
@@ -194,13 +197,18 @@ public class MyComponent : MonoBehaviour
 
     void Update()
     {
-        // In both way, you need to update the cooldown
-        _cooldown.Update();
+        // Check if the cooldown is ready and reset it
+        if(_cooldown.Restart())
+        {
+            // Do something when cooldown is ready
+        }
 
-        // Update boolean check method
+        // OR
+
+        // Check if the cooldown is ready...
         if (_cooldown.IsReady)
         {
-            _cooldown.Reset();
+            _cooldown.Reset(); // ...and reset it
             // Do something when cooldown is ready
         }
     }

--- a/Runtime/Core/Utils/CooldownManager.cs
+++ b/Runtime/Core/Utils/CooldownManager.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace BaseTool
+{
+    /// <summary>
+    /// System that manages every <see cref="Cooldown"/> that wants
+    /// to be automatically updated. <br/>
+    /// It is for BaseTool internal usage.
+    /// </summary>
+    internal class CooldownManager : MonoSingleton<CooldownManager>
+    {
+        private static List<Cooldown> _cooldowns = new List<Cooldown>();
+
+        protected override void Awake()
+        {
+            _dontDestroyOnLoad = true;
+            base.Awake();
+        }
+
+        internal void OnDestroy() => _cooldowns.Clear();
+
+        internal void Update()
+        {
+            for (int i = _cooldowns.Count - 1; i >= 0; --i)
+                _cooldowns[i].Update();
+        }
+
+        [RuntimeInitializeOnLoadMethod]
+        private static void Init() => GetOrCreateInstance();
+
+        internal static void Subscribe(Cooldown c) => _cooldowns.Add(c);
+
+        internal static void Unsubscribe(Cooldown c) => _cooldowns.Remove(c);
+    }
+}

--- a/Runtime/Core/Utils/CooldownManager.cs.meta
+++ b/Runtime/Core/Utils/CooldownManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac1f5f859895a428b9290e014ccbb715
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## `Cooldown.Restart()`

Cooldowns could be used like loop time feature (something that must be triggered each X seconds e.g.). So, it was possible to achieve this behaviour by using : 

```csharp
Cooldown _cd = 2; // each 2 seconds
...
if(_cd.IsReady)
{
    _cd.Reset();
    // Do something
}
```

This PR introduces a new method to check the `IsReady` and reset automatically : 

```csharp
Cooldown _cd = 2; // each 2 seconds
...
if(_cd.Restart())
{
    // Do something
}
```

## `CooldownManager`

You could see that `Update()` is not necessary anymore. That's because every cooldown is registered to a `CooldownManager` when they are reset ; this manager updates every registered cooldown and clear them when they're ready.

⚠️  If you are using the `Cooldown.Update()` method, or you still want to use it, you must set the `Cooldown.SubscribeToManager` to false. Without that, the cooldown would be updated twice.