### PR TITLE
Add Clear() extensions #40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add `CooldownManager` to update every `Cooldown` automatically [[#63](https://github.com/DarkRewar/BaseTool/pull/63)]
 - Add `Array.GetRandom()` extension methods [[#64](https://github.com/DarkRewar/BaseTool/issues/64)]
 - Add a `TickManager` component [[#43](https://github.com/DarkRewar/BaseTool/issues/43)]
+- Add a `Clear()` transform extensions [[#40](https://github.com/DarkRewar/BaseTool/issues/40)]
 
 ### Changes
 

--- a/Documentation~/Extensions.md
+++ b/Documentation~/Extensions.md
@@ -9,6 +9,7 @@ Table of contents:
 - [Random Extensions](#random-extensions)
 - [Range Extensions](#range-extensions)
 - [String Extensions](#string-extensions)
+- [Transform Extensions](#transform-extensions)
 - [Vector Extensions](#vector-extensions)
 
 ## Array Extensions
@@ -315,6 +316,38 @@ Will create a `string` that repeats `count` times based on the string used.
 string text = "abc";
 string repeat = text.Repeat(3);
 Debug.Log(repeat); // abcabcabc
+```
+
+## Transform Extensions
+
+### `Clear()` and `Clear(float time)`
+
+Destroy every children of a transform, using delay or not. 
+
+```csharp
+using BaseTool;
+using UnityEngine;
+
+Transform scrollView; // let's admit it's initialized
+scrollView.Clear();
+
+foreach(int i in 0..5) 
+    Instantiate(prefab, scrollView);
+```
+
+### `ClearImmediate()`
+
+Destroy every children of a transform, using the `Object.DestroyImmediate()` method. 
+
+```csharp
+using BaseTool;
+using UnityEngine;
+
+Transform scrollView; // let's admit it's initialized
+scrollView.ClearImmediate();
+
+foreach(int i in 0..5) 
+    Instantiate(prefab, scrollView);
 ```
 
 ## Vector Extensions

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ This package contains many class extensions for mainly Unity primary classes. He
 - [Random Extensions](./Documentation~/Extensions.md#random-extensions)
 - [Range Extensions](./Documentation~/Extensions.md#range-extensions)
 - [String Extensions](./Documentation~/Extensions.md#string-extensions)
+- [Transform Extensions](./Documentation~/Extensions.md#transform-extensions)
 - [Vector Extensions](./Documentation~/Extensions.md#vector-extensions)
 
 Go to the full documentation : [Class Extensions](./Documentation~/Extensions.md)

--- a/Runtime/Core/Extensions/TransformExtensions.cs
+++ b/Runtime/Core/Extensions/TransformExtensions.cs
@@ -1,0 +1,44 @@
+﻿using UnityEngine;
+
+namespace BaseTool
+{
+    public static class TransformExtensions
+    {
+        /// <summary>
+        /// <see cref="Object.Destroy(Object)"/> every direct child of the transform.
+        /// </summary>
+        /// <param name="transform"></param>
+        public static void Clear(this Transform transform)
+        {
+            for (int i = transform.childCount - 1; i >= 0; i--)
+            {
+                GameObject.Destroy(transform.GetChild(i).gameObject);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="Object.Destroy(Object)"/> every direct child of the transform.
+        /// </summary>
+        /// <param name="transform"></param>
+        /// <param name="time"></param>
+        public static void Clear(this Transform transform, float time)
+        {
+            for (int i = transform.childCount - 1; i >= 0; i--)
+            {
+                GameObject.Destroy(transform.GetChild(i).gameObject, time);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="Object.DestroyImmediate(Object)"/> every direct child of the transform.
+        /// </summary>
+        /// <param name="transform"></param>
+        public static void ClearImmediate(this Transform transform)
+        {
+            for (int i = transform.childCount - 1; i >= 0; i--)
+            {
+                GameObject.DestroyImmediate(transform.GetChild(i).gameObject);
+            }
+        }
+    }
+}

--- a/Runtime/Core/Extensions/TransformExtensions.cs.meta
+++ b/Runtime/Core/Extensions/TransformExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7309a1d9b853a5748946a97c3ac14c7d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Transform Extensions

### `Clear()` and `Clear(float time)`

Destroy every children of a transform, using delay or not. 

```csharp
using BaseTool;
using UnityEngine;

Transform scrollView; // let's admit it's initialized
scrollView.Clear();

foreach(int i in 0..5) 
    Instantiate(prefab, scrollView);
```

### `ClearImmediate()`

Destroy every children of a transform, using the `Object.DestroyImmediate()` method. 

```csharp
using BaseTool;
using UnityEngine;

Transform scrollView; // let's admit it's initialized
scrollView.ClearImmediate();

foreach(int i in 0..5) 
    Instantiate(prefab, scrollView);
```
