### PR TITLE
fix Console.cs create EventSytem when there is already one

### DIFF
--- a/Runtime/Core/Consoles/Console.cs
+++ b/Runtime/Core/Consoles/Console.cs
@@ -301,7 +301,7 @@ namespace BaseTool
 
         public static Console Instance => _instance ?? Init();
 
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         public static Console Init()
         {
             _instance = new Console();


### PR DESCRIPTION
fix Console.cs create an eventSystem when there is already one by changing the RuntimeInitializeLoadType from BeforeSceneLoad to AfterSceneLoad so FindAnyObjectByType<EventSystem> work