### PR TITLE
Fix accessor condition drawer #78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog 
 
+## 0.4.1
+
+### Changes
+
+- Fix the creation of two `EventSystem` on `Console` initialization [[#75](https://github.com/DarkRewar/BaseTool/issues/75)]
+- Fix the bug that blocks users to use `IfAttribute` with property accessor condition [[#78](https://github.com/DarkRewar/BaseTool/issues/78)]
+
 ## 0.4.0
 
 ### Improvements

--- a/Editor/Core/Tools/Drawers/ConditionalDrawer.cs
+++ b/Editor/Core/Tools/Drawers/ConditionalDrawer.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
@@ -14,11 +15,34 @@ namespace BaseTool.Tools.Drawers
             selector = condAttribute.Selector;
 
             SerializedProperty targetProperty = serializedObject.FindProperty(selector);
-            UnityEngine.Assertions.Assert.IsTrue(targetProperty != null, $"Property {selector} not found.");
-            UnityEngine.Assertions.Assert.IsTrue(
-                targetProperty.propertyType == SerializedPropertyType.Boolean,
-                $"Property {selector} must be a boolean."
-            );
+            if (targetProperty == null)
+            {
+                if (serializedObject.targetObject == null) return;
+                PropertyInfo propertyInfo = serializedObject.targetObject.GetType().GetProperty(selector);
+                UnityEngine.Assertions.Assert.IsTrue(propertyInfo != null, $"Property of field {selector} not found.");
+                UnityEngine.Assertions.Assert.IsTrue(propertyInfo.PropertyType == typeof(bool), $"Property of field {selector} is not a boolean.");
+            }
+            else
+            {
+                //UnityEngine.Assertions.Assert.IsTrue(targetProperty != null, $"Property {selector} not found.");
+                UnityEngine.Assertions.Assert.IsTrue(
+                    targetProperty.propertyType == SerializedPropertyType.Boolean,
+                    $"Property {selector} must be a boolean.");
+            }
+        }
+
+        protected bool GetValueFromObject(SerializedObject serializedObject, string selector)
+        {
+            SerializedProperty targetProperty = serializedObject.FindProperty(selector);
+            if (targetProperty == null)
+            {
+                PropertyInfo propertyInfo = serializedObject.targetObject.GetType().GetProperty(selector);
+                return (bool)propertyInfo.GetValue(serializedObject.targetObject);
+            }
+            else
+            {
+                return targetProperty.boolValue;
+            }
         }
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)

--- a/Editor/Core/Tools/Drawers/IfDrawer.cs
+++ b/Editor/Core/Tools/Drawers/IfDrawer.cs
@@ -9,8 +9,7 @@ namespace BaseTool.Tools.Drawers
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
             CheckObject(property.serializedObject, out string selector);
-            SerializedProperty targetProperty = property.serializedObject.FindProperty(selector);
-            if (targetProperty.boolValue)
+            if (GetValueFromObject(property.serializedObject, selector))
             {
                 _display = true;
                 EditorGUI.PropertyField(position, property, label);

--- a/Editor/Core/Tools/Drawers/IfNotDrawer.cs
+++ b/Editor/Core/Tools/Drawers/IfNotDrawer.cs
@@ -9,8 +9,7 @@ namespace BaseTool.Tools.Drawers
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
             CheckObject(property.serializedObject, out string selector);
-            SerializedProperty targetProperty = property.serializedObject.FindProperty(selector);
-            if (!targetProperty.boolValue)
+            if (!GetValueFromObject(property.serializedObject, selector))
             {
                 _display = true;
                 EditorGUI.PropertyField(position, property, label);


### PR DESCRIPTION
Fix the bug that throws an error if the condition is an accessor instead of a field