### PR TITLE
Add MathUtils.Approximately #86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## 0.4.1
 
+### Improvements
+
+- Add the `MathUtils.Approximately()` method as a tolerant equivalent of `Mathf.Approximately` [[#86](https://github.com/DarkRewar/BaseTool/issues/86)]
+
 ### Changes
 
 - Fix the creation of two `EventSystem` on `Console` initialization [[#75](https://github.com/DarkRewar/BaseTool/issues/75)]
 - Fix the bug that blocks users to use `IfAttribute` with property accessor condition [[#78](https://github.com/DarkRewar/BaseTool/issues/78)]
-- Add unit tests to avoid regression [[87](https://github.com/DarkRewar/BaseTool/issues/78)]
+- Add unit tests to avoid regression [[#87](https://github.com/DarkRewar/BaseTool/issues/87)]
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -428,6 +428,24 @@ MathUtils.Modulo(-1, 5); // = 4
 MathUtils.Modulo(-3, 5); // = 2
 ```
 
+#### `Approximately(float a, float b, float tolerance = 0.001f)`
+
+The [`UnityEngine.Mathf.Approximately`](https://docs.unity3d.com/ScriptReference/Mathf.Approximately.html)
+method is useful but not enough tolerant if you want to check values that are too different.
+
+For example: if you want to make a deadzone on your Vector3 magnitude when it goes lower than 0.01f, 
+the `Mathf.Approximately(vector.magnitude, 0)` could return false if your magnitude is too high.
+
+```csharp
+using BaseTool; 
+
+MathUtils.Approximately(0.1f, 0.001f); // true
+MathUtils.Approximately(1, 0.001f); // false
+
+MathUtils.Approximately(1.1f, 1.2f, 0.2f); // true
+MathUtils.Approximately(1.1f, 1.2f, 0.05f); // false
+```
+
 ### TickManager
 
 The `TickManager` component allows you to create a system that sends a tick every *x* seconds.

--- a/Runtime/Core/Utils/MathUtils.cs
+++ b/Runtime/Core/Utils/MathUtils.cs
@@ -1,4 +1,6 @@
-﻿namespace BaseTool
+﻿using UnityEngine;
+
+namespace BaseTool
 {
     public static class MathUtils
     {
@@ -12,6 +14,19 @@
         public static int Modulo(int index, int count)
         {
             return (index % count + count) % count;
+        }
+
+        /// <summary>
+        /// Work quite like the <see cref="UnityEngine.Mathf.Approximately(float, float)"/>
+        /// method but allows a third arguments to change the tolerance.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <param name="tolerance"></param>
+        /// <returns></returns>
+        public static bool Approximately(float a, float b, float tolerance = 0.001f)
+        {
+            return Mathf.Abs(b - a) < Mathf.Max(Mathf.Max(Mathf.Abs(a), Mathf.Abs(b)), tolerance);
         }
     }
 }

--- a/Tests/Runtime/MathUtilsTest.cs
+++ b/Tests/Runtime/MathUtilsTest.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using UnityEngine;
 
 namespace BaseTool.Tests
 {
@@ -28,6 +29,34 @@ namespace BaseTool.Tests
         public void MathUtilsMinus9Modulo6()
         {
             Assert.IsTrue(MathUtils.Modulo(-9, 6) == 3);
+        }
+
+        #endregion
+
+        #region MathUtils.Approximately
+
+        [Test(Author = "DarkRewar", Description = "Test if two numbers are near")]
+        public void MathUtilsDefaultApproximately()
+        {
+            Assert.IsTrue(MathUtils.Approximately(0.01f, 0.001f));
+        }
+
+        [Test(Author = "DarkRewar", Description = "Test if two numbers are near")]
+        public void MathUtilsApproximatelyWithVector3()
+        {
+            float value = 1E-16f;
+            var smallVector = new Vector3(value, value, value);
+            Assert.IsFalse(Mathf.Approximately(smallVector.magnitude, 0));
+            Assert.IsTrue(MathUtils.Approximately(smallVector.magnitude, 0));
+        }
+
+        [Test(Author = "DarkRewar", Description = "Test if two numbers are near")]
+        public void MathUtilsApproximatelyWithVector3AndTooSmallTolerence()
+        {
+            float value = 1E-16f;
+            var smallVector = new Vector3(value, value, value);
+            Assert.IsFalse(Mathf.Approximately(smallVector.magnitude, 0));
+            Assert.IsFalse(MathUtils.Approximately(smallVector.magnitude, 0, 1E-24f));
         }
 
         #endregion


### PR DESCRIPTION
#### `Approximately(float a, float b, float tolerance = 0.001f)`

The [`UnityEngine.Mathf.Approximately`](https://docs.unity3d.com/ScriptReference/Mathf.Approximately.html)
method is useful but not enough tolerant if you want to check values that are too different.

For example: if you want to make a deadzone on your Vector3 magnitude when it goes lower than 0.01f, 
the `Mathf.Approximately(vector.magnitude, 0)` could return false if your magnitude is too high.

```csharp
using BaseTool; 

MathUtils.Approximately(0.1f, 0.001f); // true
MathUtils.Approximately(1, 0.001f); // false

MathUtils.Approximately(1.1f, 1.2f, 0.2f); // true
MathUtils.Approximately(1.1f, 1.2f, 0.05f); // false
```