### PR TITLE
Add EnableIf and DisableIf #95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a `MessageAttribute` to display message in the inspector [[#91](https://github.com/DarkRewar/BaseTool/issues/91)]
 - Add a `ButtonAttribute` to display a button for methods in the inspector [[#18](https://github.com/DarkRewar/BaseTool/issues/18)]
 - Add DynamicExpresso library to use code evaluation for conditional attributes [[#74](https://github.com/DarkRewar/BaseTool/issues/74)]
+- Add `EnableIf` and `DisableIf` attributes to mark field as readonly is condition is valid or not [[#95](https://github.com/DarkRewar/BaseTool/issues/95)]
 
 ## 0.4.1
 

--- a/Editor/Core/Tools/Drawers/DisableIfDrawer.cs
+++ b/Editor/Core/Tools/Drawers/DisableIfDrawer.cs
@@ -1,0 +1,17 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace BaseTool.Tools.Drawers
+{
+    [CustomPropertyDrawer(typeof(DisableIfAttribute))]
+    public class DisableIfDrawer : ConditionalDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            GUI.enabled = !GetValueFromObject(property.serializedObject);
+            EditorGUI.PropertyField(position, property, label);
+            GUI.enabled = true;
+            _display = true;
+        }
+    }
+}

--- a/Editor/Core/Tools/Drawers/DisableIfDrawer.cs.meta
+++ b/Editor/Core/Tools/Drawers/DisableIfDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01d8b214e8d09fa4c826588f614f13a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Core/Tools/Drawers/EnableIfDrawer.cs
+++ b/Editor/Core/Tools/Drawers/EnableIfDrawer.cs
@@ -1,0 +1,17 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace BaseTool.Tools.Drawers
+{
+    [CustomPropertyDrawer(typeof(EnableIfAttribute))]
+    public class EnableIfDrawer : ConditionalDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            GUI.enabled = GetValueFromObject(property.serializedObject);
+            EditorGUI.PropertyField(position, property, label);
+            GUI.enabled = true;
+            _display = true;
+        }
+    }
+}

--- a/Editor/Core/Tools/Drawers/EnableIfDrawer.cs.meta
+++ b/Editor/Core/Tools/Drawers/EnableIfDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 769592078f5e84f4d90fe8666c191caf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ How to install:
     - [MinMaxAttribute](#minmaxattribute)
     - [IfAttribute](#ifattribute)
     - [IfNotAttribute](#ifnotattribute)
+    - [EnableIfAttribute](#enableifattribute)
+    - [DisableIfAttribute](#disableifattribute)
     - [ReadOnlyAttribute](#readonlyattribute)
     - [MessageAttribute](#messageattribute)
     - [ButtonAttribute](#buttonattribute)
@@ -1002,6 +1004,48 @@ public class MyClass : MonoBehaviour
     
     [If("ProjectileSpeed > 1")]
     public GameObject ProjectileFX;
+}
+```
+
+### `EnableIfAttribute`
+
+This attribute can mark its field as readonly in the inspector if 
+the condition is false.
+
+```csharp
+using BaseTool;
+using UnityEngine;
+
+public class MyClass : MonoBehaviour
+{
+    public bool IsStrong = true;
+
+    [EnableIf(nameof(IsStrong))]
+    public float Strength = 10f;
+
+    [EnableIf("!IsStrong")]
+    public float NonStrength = 10f;
+}
+```
+
+### `DisableIfAttribute`
+
+This attribute can mark its field as readonly in the inspector if 
+the condition is true.
+
+```csharp
+using BaseTool;
+using UnityEngine;
+
+public class MyClass : MonoBehaviour
+{
+    public bool IsStrong = true;
+
+    [DisableIf("!IsStrong")]
+    public float Strength = 10f;
+
+    [DisableIf(nameof(IsStrong))]
+    public float NonStrength = 10f;
 }
 ```
 

--- a/Runtime/Core/Tools/Attributes/DisableIfAttribute.cs
+++ b/Runtime/Core/Tools/Attributes/DisableIfAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace BaseTool
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class DisableIfAttribute : ConditionalAttribute
+    {
+        public DisableIfAttribute(string selector) : base(selector) { }
+    }
+}

--- a/Runtime/Core/Tools/Attributes/DisableIfAttribute.cs.meta
+++ b/Runtime/Core/Tools/Attributes/DisableIfAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af54238217acf0942ba891e3355f3c36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Core/Tools/Attributes/EnableIfAttribute.cs
+++ b/Runtime/Core/Tools/Attributes/EnableIfAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace BaseTool
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class EnableIfAttribute : ConditionalAttribute
+    {
+        public EnableIfAttribute(string selector) : base(selector) { }
+    }
+}

--- a/Runtime/Core/Tools/Attributes/EnableIfAttribute.cs.meta
+++ b/Runtime/Core/Tools/Attributes/EnableIfAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfb75f1a736a71b4697d5314c4032594
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### `EnableIfAttribute`

This attribute can mark its field as readonly in the inspector if 
the condition is false.

```csharp
using BaseTool;
using UnityEngine;

public class MyClass : MonoBehaviour
{
    public bool IsStrong = true;

    [EnableIf(nameof(IsStrong))]
    public float Strength = 10f;

    [EnableIf("!IsStrong")]
    public float NonStrength = 10f;
}
```

### `DisableIfAttribute`

This attribute can mark its field as readonly in the inspector if 
the condition is true.

```csharp
using BaseTool;
using UnityEngine;

public class MyClass : MonoBehaviour
{
    public bool IsStrong = true;

    [DisableIf("!IsStrong")]
    public float Strength = 10f;

    [DisableIf(nameof(IsStrong))]
    public float NonStrength = 10f;
}
```