### PR TITLE
Add ToSerializableDictionary extension #100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add DynamicExpresso library to use code evaluation for conditional attributes [[#74](https://github.com/DarkRewar/BaseTool/issues/74)]
 - Add `EnableIf` and `DisableIf` attributes to mark field as readonly is condition is valid or not [[#95](https://github.com/DarkRewar/BaseTool/issues/95)]
 - Add `Suffix` and `Prefix` attributes to add labels before or after a field in inspector [[#98](https://github.com/DarkRewar/BaseTool/issues/98)]
+- Add `ToSerializableDictionary` extension to `Dictionary` class [[#100](https://github.com/DarkRewar/BaseTool/issues/100)]
 
 ## 0.4.1
 

--- a/Documentation~/Extensions.md
+++ b/Documentation~/Extensions.md
@@ -4,6 +4,7 @@ Table of contents:
 - [Array Extensions](#array-extensions)
 - [Camera Extensions](#camera-extensions)
 - [Color Extensions](#color-extensions)
+- [Dictionary Extensions](#dictionary-extensions)
 - [List Extensions](#list-extensions)
 - [Number Extensions](#number-extensions)
 - [Random Extensions](#random-extensions)
@@ -121,6 +122,27 @@ Color.blue.ToHexAlpha(); // #0000FFFF
 
 Color green = new Color(0, 1, 0, 0.5f);
 green.ToHexAlpha(); // #00FF007F
+```
+
+## Dictionary Extensions
+
+### `ToSerializableDictionary()`
+
+Returns a `SerializableDictionary` from a `Dictionary`. This is mostly used to
+converts a `Dictionary` into a class that can be displayed, read and serialized
+in the inspector. 
+
+See [SerializableDictionary](../README.md#serializabledictionary)
+for more informations.
+
+```csharp
+using BaseTool;
+using System.Collections.Generic;
+
+public SerializableDictionary<int, string> SerializedDictionary;
+public Dictionary<int, string> Dictionary;
+
+SerializedDictionary = Dictionary.ToSerializableDictionary();
 ```
 
 ## List Extensions

--- a/README.md
+++ b/README.md
@@ -320,6 +320,33 @@ It also tells you when two keys already exists in the dictionary.
 
 ![serializable_dictionary_drawer](./Documentation~/Editor/serializable_dictionary_drawer.png)
 
+You can cast `Dictionary` to `SerializableDictionary` using
+`.ToSerializableDictionary()` method and you also can cast `SerializableDictionary` to `Dictionary` using using implicit cast.
+
+```csharp
+using BaseTool;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Test : MonoBehaviour
+{
+    public SerializableDictionary<int, string> SerializedDictionary;
+
+    public Dictionary<int, string> Dictionary;
+    
+    void Start()
+    {
+        // Dictionary -> SerializableDictionary
+        SerializedDictionary = Dictionary.ToSerializableDictionary();
+        //or
+        SerializedDictionary = new(Dictionary);
+
+        // SerializableDictionary -> Dictionary
+        Dictionary = SerializedDictionary;
+    }
+}
+```
+
 ### PonderateRandom
 
 Many games uses randomizer tweaked to let some elements happens more times than others.

--- a/Runtime/Core/Extensions/DictionaryExtensions.cs
+++ b/Runtime/Core/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace BaseTool
+{
+    public static class DictionaryExtensions
+    {
+        public static SerializableDictionary<TKey, TValue> ToSerializableDictionary<TKey, TValue>(this Dictionary<TKey, TValue> dictionary)
+        {
+            return new SerializableDictionary<TKey, TValue>(dictionary);
+        }
+    }
+}

--- a/Runtime/Core/Extensions/DictionaryExtensions.cs.meta
+++ b/Runtime/Core/Extensions/DictionaryExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c459624fd6d6a7d48bd190b323fa0434
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Core/Utils/SerializableDictionary.cs
+++ b/Runtime/Core/Utils/SerializableDictionary.cs
@@ -2,8 +2,8 @@
  * Based on the plugin [Serializable-Dictionary-Unity](https://github.com/EduardMalkhasyan/Serializable-Dictionary-Unity)
  * Created by [EduardMalkhasyan](https://github.com/EduardMalkhasyan)
  */
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace BaseTool
@@ -13,7 +13,12 @@ namespace BaseTool
     {
         [SerializeField] private List<SerializedDictionaryKVPProps<TKey, TValue>> dictionaryList = new();
 
-        void ISerializationCallbackReceiver.OnBeforeSerialize()
+        public SerializableDictionary(Dictionary<TKey, TValue> reference) : base(reference)
+        {
+            BeforeSerialize();
+        }
+
+        private void BeforeSerialize()
         {
             foreach (var kVP in this)
             {
@@ -35,6 +40,8 @@ namespace BaseTool
                 dictionaryList[i].index = i;
             }
         }
+
+        void ISerializationCallbackReceiver.OnBeforeSerialize() => BeforeSerialize();
 
         void ISerializationCallbackReceiver.OnAfterDeserialize()
         {
@@ -97,5 +104,4 @@ namespace BaseTool
                 => new KeyValuePair<TypeKey, TypeValue>(kvp.Key, kvp.Value);
         }
     }
-
 }


### PR DESCRIPTION
You can cast `Dictionary` to `SerializableDictionary` using
`.ToSerializableDictionary()` method and you also can cast `SerializableDictionary` to `Dictionary` using using implicit cast.

```csharp
using BaseTool;
using System.Collections.Generic;
using UnityEngine;

public class Test : MonoBehaviour
{
    public SerializableDictionary<int, string> SerializedDictionary;

    public Dictionary<int, string> Dictionary;
    
    void Start()
    {
        // Dictionary -> SerializableDictionary
        SerializedDictionary = Dictionary.ToSerializableDictionary();
        //or
        SerializedDictionary = new(Dictionary);

        // SerializableDictionary -> Dictionary
        Dictionary = SerializedDictionary;
    }
}
```