### PR TITLE
103 add a kill method for running cooldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add `EnableIf` and `DisableIf` attributes to mark field as readonly is condition is valid or not [[#95](https://github.com/DarkRewar/BaseTool/issues/95)]
 - Add `Suffix` and `Prefix` attributes to add labels before or after a field in inspector [[#98](https://github.com/DarkRewar/BaseTool/issues/98)]
 - Add `ToSerializableDictionary` extension to `Dictionary` class [[#100](https://github.com/DarkRewar/BaseTool/issues/100)]
+- Add `Stop()`, `Pause()` and `Resume()` methods to `Cooldown` class [[#103](https://github.com/DarkRewar/BaseTool/issues/103)]
 
 ## 0.4.1
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ public class MyComponent : MonoBehaviour
 Every `Cooldown` is updated by an internal `CooldownManager`, you don't have to call the `Cooldown.Update()` method yourself.
 If you want to manage the cooldown, you can set the `Cooldown.SubscribeToManager` to false.
 
+You can pause and resume the cooldown by using `Cooldown.Pause()` and `Cooldown.Resume()` methods.
+If you want to totally stop the cooldown (and remove it from the `CooldownManager`)
+you can use the `Cooldown.Stop()` method.
+
 ```csharp
 using BaseTool;
 using UnityEngine;
@@ -231,6 +235,13 @@ public class MyComponent : MonoBehaviour
             _cooldown.Reset(); // ...and reset it
             // Do something when cooldown is ready
         }
+
+        if(Input.GetKeyDown(KeyCode.P))
+            _cooldown.Pause();
+        else if(Input.GetKeyDown(KeyCode.R))
+            _cooldown.Resume();
+        else if(Input.GetKeyDown(KeyCode.S))
+            _cooldown.Stop();
     }
 
     private void OnCooldownIsReady()

--- a/Runtime/Core/Cooldown.cs
+++ b/Runtime/Core/Cooldown.cs
@@ -30,6 +30,12 @@ namespace BaseTool
         public bool IsReady => TimeLeft <= 0;
 
         /// <summary>
+        /// Determines if the cooldown must <see cref="Update"/> or not.<br/>
+        /// If true, the <see cref="Update"/> will be ignored.
+        /// </summary>
+        public bool IsPaused { get; private set; } = false;
+
+        /// <summary>
         /// If true, let the <see cref="Cooldown"/> be managed and updated by
         /// the <see cref="CooldownManager"/>.<br/>
         /// If you want to update the cooldown on your own, set this to false.<br/>
@@ -55,7 +61,7 @@ namespace BaseTool
         /// <param name="time">Elapsed time, in seconds</param>
         public void Update(float time)
         {
-            if (IsReady) return;
+            if (IsReady || IsPaused) return;
             TimeLeft -= time;
 
             if (IsReady)
@@ -88,6 +94,32 @@ namespace BaseTool
 
             Reset();
             return true;
+        }
+
+        /// <summary>
+        /// Pauses the cooldown. <see cref="Update"/> will totally be ignored
+        /// until the <see cref="Resume"/> is called or the <see cref="IsPaused"/>
+        /// is set to false.
+        /// </summary>
+        public void Pause() => IsPaused = !IsPaused && !IsReady;
+
+        /// <summary>
+        /// Unpauses the cooldown by setting <see cref="IsPaused"/> to false.
+        /// </summary>
+        public void Resume() => IsPaused = false;
+
+        /// <summary>
+        /// Totally stops the cooldown (also removes it from the <see cref="CooldownManager"/>)
+        /// and set the time left to 0. The cooldown becomes ready.
+        /// </summary>
+        public void Stop()
+        {
+            if (IsReady) return;
+
+            if (SubscribeToManager)
+                CooldownManager.Unsubscribe(this);
+            TimeLeft = 0;
+            IsPaused = false;
         }
 
         /// <summary>


### PR DESCRIPTION
You can pause and resume the cooldown by using `Cooldown.Pause()` and `Cooldown.Resume()` methods.
If you want to totally stop the cooldown (and remove it from the `CooldownManager`)
you can use the `Cooldown.Stop()` method.