### PR TITLE
Added a `IsPointInsidePolygon` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,29 @@ MathUtils.Approximately(1.1f, 1.2f, 0.2f); // true
 MathUtils.Approximately(1.1f, 1.2f, 0.05f); // false
 ```
 
+#### `IsPointInsidePolygon(Vector2 point, Vector2[] polygon)`
+
+Check if a point is inside a polygon (determined by a list of `Vector2`). 
+Also exists for `Vector2Int` by using 
+`IsPointInsidePolygon(Vector2Int point, Vector2Int[] polygon)`.
+
+```csharp
+using BaseTool;
+
+List<Vector2> square = new()
+{
+   new(0, 0),
+   new(0, 1),
+   new(1, 1),
+   new(1, 0)
+};
+
+MathUtils.IsPointInsidePolygon(new Vector2(0.5f, 0.5f), points)); // true
+MathUtils.IsPointInsidePolygon(new Vector2(-1, -1), points)); // false
+```
+
+*Note: currently, there are no `Vector3` equivalent.*
+
 ### TickManager
 
 The `TickManager` component allows you to create a system that sends a tick every *x* seconds.

--- a/Runtime/Core/Utils/MathUtils.cs
+++ b/Runtime/Core/Utils/MathUtils.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
 namespace BaseTool
 {
@@ -28,5 +29,77 @@ namespace BaseTool
         {
             return Mathf.Abs(b - a) < Mathf.Max(Mathf.Max(Mathf.Abs(a), Mathf.Abs(b)), tolerance);
         }
+
+        /// <summary>
+        /// Check if a point is inside a polygon (list of <see cref="Vector2"/>).
+        /// <br/> 2D usage only.
+        /// </summary>
+        /// <param name="point">Point to check</param>
+        /// <param name="polygon">List of <see cref="Vector2"/> which forms the polygon.</param>
+        /// <returns></returns>
+        /// <inheritdoc cref="https://codereview.stackexchange.com/a/108903"/>
+        public static bool IsPointInsidePolygon(Vector2 point, Vector2[] polygon)
+        {
+            int polygonLength = polygon.Length, i=0;
+            bool inside = false;
+            // x, y for tested point.
+            float pointX = point.x, pointY = point.y;
+            // start / end point for the current polygon segment.
+            float startX, startY, endX, endY;
+            Vector2 endPoint = polygon[polygonLength-1];           
+            endX = endPoint.x; 
+            endY = endPoint.y;
+            while (i < polygonLength) 
+            {
+                startX = endX;           startY = endY;
+                endPoint = polygon[i++];
+                endX = endPoint.x;       endY = endPoint.y;
+                //
+                inside ^= ( endY > pointY ^ startY > pointY ) /* ? pointY inside [startY;endY] segment ? */
+                          && /* if so, test if it is under the segment */
+                          ( (pointX - endX) < (pointY - endY) * (startX - endX) / (startY - endY) ) ;
+            }
+            return inside;
+        }
+        
+        /// <inheritdoc cref="IsPointInsidePolygon(UnityEngine.Vector2,UnityEngine.Vector2[])"/>
+        public static bool IsPointInsidePolygon(Vector2 point, List<Vector2> polygon)
+            => IsPointInsidePolygon(point, polygon.ToArray());
+        
+        /// <summary>
+        /// Check if a point is inside a polygon (list of <see cref="Vector2Int"/>).
+        /// <br/> 2D usage only.
+        /// </summary>
+        /// <param name="point">Point to check</param>
+        /// <param name="polygon">List of <see cref="Vector2"/> which forms the polygon.</param>
+        /// <returns></returns>
+        /// <inheritdoc cref="https://codereview.stackexchange.com/a/108903"/>
+        public static bool IsPointInsidePolygon(Vector2Int point, Vector2Int[] polygon)
+        {
+            int polygonLength = polygon.Length, i=0;
+            bool inside = false;
+            // x, y for tested point.
+            float pointX = point.x, pointY = point.y;
+            // start / end point for the current polygon segment.
+            float startX, startY, endX, endY;
+            Vector2 endPoint = polygon[polygonLength-1];           
+            endX = endPoint.x; 
+            endY = endPoint.y;
+            while (i < polygonLength) 
+            {
+                startX = endX;           startY = endY;
+                endPoint = polygon[i++];
+                endX = endPoint.x;       endY = endPoint.y;
+                //
+                inside ^= ( endY > pointY ^ startY > pointY ) /* ? pointY inside [startY;endY] segment ? */
+                          && /* if so, test if it is under the segment */
+                          ( (pointX - endX) < (pointY - endY) * (startX - endX) / (startY - endY) ) ;
+            }
+            return inside;
+        }
+        
+        /// <inheritdoc cref="IsPointInsidePolygon(UnityEngine.Vector2Int,UnityEngine.Vector2Int[])"/>
+        public static bool IsPointInsidePolygon(Vector2Int point, List<Vector2Int> polygon)
+            => IsPointInsidePolygon(point, polygon.ToArray());
     }
 }

--- a/Tests/Runtime/MathUtilsTest.cs
+++ b/Tests/Runtime/MathUtilsTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -59,6 +60,82 @@ namespace BaseTool.Tests
             Assert.IsFalse(MathUtils.Approximately(smallVector.magnitude, 0, 1E-24f));
         }
 
+        #endregion
+        
+        #region MathUtils.IsPointInsidePolygon
+
+        private List<Vector2> GenerateSquare() => new()
+        {
+            new(0, 0),
+            new(0, 1),
+            new(1, 1),
+            new(1, 0)
+        };
+        
+        private List<Vector2> GenerateOctagon() => new()
+        {
+            new(1, 0),
+            new(2, 0),
+            new(3, 1),
+            new(3, 2),
+            new(2, 3),
+            new(1, 3),
+            new(0, 2),
+            new(0, 1)
+        };
+        
+        private List<Vector2> GenerateV() => new()
+        {
+            new(0, 0),
+            new(3, 3),
+            new(2, 3),
+            new(0, 1),
+            new(-2, 3),
+            new(-3, 3)
+        };
+        
+        [Test(Author = "DarkRewar", Description = "Test if a point is inside a square")]
+        public void MathUtilsPointIsInsideSquare()
+        {
+            List<Vector2> points = GenerateSquare();
+            Assert.IsTrue(MathUtils.IsPointInsidePolygon(new Vector2(0.5f, 0.5f), points));
+        }
+        
+        [Test(Author = "DarkRewar", Description = "Test if a point is not inside a square")]
+        public void MathUtilsPointIsOutsideSquare()
+        {
+            List<Vector2> points = GenerateSquare();
+            Assert.IsFalse(MathUtils.IsPointInsidePolygon(new Vector2(-1, -1), points));
+        }
+        
+        [Test(Author = "DarkRewar", Description = "Test if a point is inside an octagon")]
+        public void MathUtilsPointIsInsideOctagon()
+        {
+            List<Vector2> points = GenerateOctagon();
+            Assert.IsTrue(MathUtils.IsPointInsidePolygon(new Vector2(2.5f, 1.5f), points));
+        }
+        
+        [Test(Author = "DarkRewar", Description = "Test if a point is outside an octagon")]
+        public void MathUtilsPointIsOutsideOctagon()
+        {
+            List<Vector2> points = GenerateOctagon();
+            Assert.IsFalse(MathUtils.IsPointInsidePolygon(new Vector2(3, 3), points));
+        }
+        
+        [Test(Author = "DarkRewar", Description = "Test if a point is inside a complex polygon")]
+        public void MathUtilsPointIsInsideComplexPolygon()
+        {
+            List<Vector2> points = GenerateV();
+            Assert.IsTrue(MathUtils.IsPointInsidePolygon(new Vector2(-1f, 1.5f), points));
+        }
+        
+        [Test(Author = "DarkRewar", Description = "Test if a point is outside a complex polygon")]
+        public void MathUtilsPointIsOutsideComplexPolygon()
+        {
+            List<Vector2> points = GenerateV();
+            Assert.IsFalse(MathUtils.IsPointInsidePolygon(new Vector2(0, 2), points));
+        }
+        
         #endregion
     }
 }


### PR DESCRIPTION
#### `IsPointInsidePolygon(Vector2 point, Vector2[] polygon)`

Check if a point is inside a polygon (determined by a list of `Vector2`). 
Also exists for `Vector2Int` by using 
`IsPointInsidePolygon(Vector2Int point, Vector2Int[] polygon)`.

```csharp
using BaseTool;

List<Vector2> square = new()
{
   new(0, 0),
   new(0, 1),
   new(1, 1),
   new(1, 0)
};

MathUtils.IsPointInsidePolygon(new Vector2(0.5f, 0.5f), points)); // true
MathUtils.IsPointInsidePolygon(new Vector2(-1, -1), points)); // false
```

*Note: currently, there are no `Vector3` equivalent.*

closes #108 