### PR TITLE
Improve Console settings and return (#120 #121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Improvements
 
+- Add an option to set `PanelSettings` on `ConsoleSettings` [[#121](https://github.com/DarkRewar/BaseTool/issues/121)]
+- Allows numpad enter as return keycode for `Console` [[#120](https://github.com/DarkRewar/BaseTool/issues/120)]
+
 ## Fixes
 
 ## 0.5.0

--- a/Runtime/Core/Consoles/ConsoleManager.cs
+++ b/Runtime/Core/Consoles/ConsoleManager.cs
@@ -18,13 +18,16 @@ namespace BaseTool
         internal bool IsKeyPressed =>
             !Console.Settings.UseCustomInput
             && Input.GetKeyDown(Console.Settings.ToggleKeyCode)
-            && (!Console.Settings.ToggleKeyCodeCtrl || Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl))
+            && (!Console.Settings.ToggleKeyCodeCtrl || Input.GetKey(KeyCode.LeftControl) ||
+                Input.GetKey(KeyCode.RightControl))
             && (!Console.Settings.ToggleKeyCodeAlt || Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt));
 
         private void Awake()
         {
             _uiDocument = GetComponent<UIDocument>();
-            _uiDocument.panelSettings = Resources.Load<PanelSettings>("ConsolePanelSettings");
+            _uiDocument.panelSettings = Console.Settings.PanelSettings
+                ? Console.Settings.PanelSettings
+                : Resources.Load<PanelSettings>("ConsolePanelSettings");
             _uiDocument.visualTreeAsset = Resources.Load<VisualTreeAsset>("ConsoleView");
             _uiDocument.rootVisualElement.style.display = DisplayStyle.None;
         }
@@ -92,7 +95,7 @@ namespace BaseTool
                 _textField.selectIndex = completion.Length;
             }
 
-            if (evt.keyCode != KeyCode.Return) return;
+            if (evt.keyCode != KeyCode.Return && evt.keyCode != KeyCode.KeypadEnter) return;
 
             Console.EnqueueCommand(_textField.text);
             _textField.SetValueWithoutNotify(null);
@@ -105,7 +108,7 @@ namespace BaseTool
                 _textField.SetValueWithoutNotify(completion);
             }
 
-            if (evt.keyCode != KeyCode.Return) return;
+            if (evt.keyCode != KeyCode.Return && evt.keyCode != KeyCode.KeypadEnter) return;
 
             Console.EnqueueCommand(_textField.text);
             _textField.SetValueWithoutNotify(null);

--- a/Runtime/Core/Consoles/ConsoleSettings.cs
+++ b/Runtime/Core/Consoles/ConsoleSettings.cs
@@ -1,10 +1,14 @@
 using UnityEngine;
+using UnityEngine.UIElements;
 
 namespace BaseTool
 {
     public class ConsoleSettings : ScriptableObject
     {
         public const string DefaultSettingsFile = "ConsoleSettings";
+
+        [Header("UI Toolkit settings")] 
+        public PanelSettings PanelSettings;
 
         [Header("Opened settings")]
         public float OpenedTimeScale = 0;


### PR DESCRIPTION
- Add an option to set `PanelSettings` on `ConsoleSettings` [[#121](https://github.com/DarkRewar/BaseTool/issues/121)]
- Allows numpad enter as return keycode for `Console` [[#120](https://github.com/DarkRewar/BaseTool/issues/120)]